### PR TITLE
various tweaks and an addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can use **Composer**, **Git** or simply **Download the Release**
 
 The preferred method is via [composer](https://getcomposer.org). Follow the [installation instructions](https://getcomposer.org/doc/00-intro.md) if you do not already have composer installed.
 
-Once composer is installed, simply execute this command from your project directory:
+Once composer is installed, simply execute this command from the shell in your project directory:
 
 ```sh
 composer require art-of-wifi/unifi-api-client
@@ -176,7 +176,7 @@ require_once('vendor/autoload.php');
  */
 $unifi_connection = new UniFi_API\Client($controller_user, $controller_password, $controller_url, $site_id, $controller_version);
 $login            = $unifi_connection->login();
-$results          = $unifi_connection->list_alarms(); // returns an PHP array containing alarm objects
+$results          = $unifi_connection->list_alarms(); // returns a PHP array containing alarm objects
 ```
 
 Please refer to the `examples/` directory for some more detailed examples which you can use as a starting point for your own PHP code.

--- a/examples/test_connection.php
+++ b/examples/test_connection.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Test the connection to your UniFi controller
+ *
+ * contributed by: Art of WiFi
+ * description: PHP script to check/debug the connection to your controller using PHP and cURL
+ */
+
+/**
+ * Include the config file (place your credentials etc. there if not already present),
+ * see the config.template.php file for an example.
+ * (will only be used here to get the URL to the controller)
+ */
+require_once('config.php');
+
+/**
+ * Check whether the cURL module supports SSL
+ */
+if (!curl_version()['features'] & CURL_VERSION_SSL) {
+    print 'SSL is not supported with this cURL installation!' . PHP_EOL;
+}
+
+/**
+ * create cURL resource
+ */
+$ch = curl_init();
+
+/**
+ * Set the required cURL options
+ */
+curl_setopt($ch, CURLOPT_URL, $controllerurl);
+curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);
+
+/**
+ * This cURL option can have a value of 0-6 see this URL for more details:
+ * http://php.net/manual/en/function.curl-setopt.php
+ * 0 is the default value and is used by the PHP API client class
+ */
+curl_setopt($ch, CURLOPT_SSLVERSION, 0);
+
+/**
+ * Be more verbose
+ */
+curl_setopt($ch, CURLOPT_VERBOSE, true);
+
+/**
+ * $results contains the output as returned by the cURL request,
+ * returns true when successful, else returns false
+ */
+print 'verbose output from the cURL request:' . PHP_EOL;
+$results = curl_exec($ch);
+
+print PHP_EOL . 'curl_getinfo output:' . PHP_EOL;
+print_r(curl_getinfo($ch));
+
+/**
+ * If we receive a cURL error, output it before the results
+ */
+if (curl_errno($ch)) {
+    print PHP_EOL . 'cURL error: ' . curl_error($ch) . PHP_EOL;
+}
+
+print PHP_EOL . '$results:' . PHP_EOL;
+print_r($results);
+print PHP_EOL;

--- a/src/Client.php
+++ b/src/Client.php
@@ -171,13 +171,11 @@ class Client
      */
     public function set_site($site)
     {
-
-        if (strlen($site) === 8 || $site === 'default') {
+        if (strlen($site) !== 8 && $site !== 'default' && $this->debug) {
             error_log('The provided (short) site name is probably incorrect');
         }
 
         $this->site = $site;
-
         return $this->site;
     }
 


### PR DESCRIPTION
- more relaxed handling of $site in set_site(), now we only issue an error message when provided (short) site name is probably incorrect and debug mode is
true
- added test_connection.php, a command line script which can be used to quickly test the connection to your controller with various cURL options which you can
quickly change